### PR TITLE
Add security hardening and compliance documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The `docs/` directory maintains enterprise-grade playbooks, strategies, and spec
 - [Security-Compliance.md](docs/Security-Compliance.md)
 - [RiskManagementDocument.md](docs/RiskManagementDocument.md)
 - [Legal-and-Ethical-Considerations.md](docs/Legal-and-Ethical-Considerations.md)
+- [Security Compliance Overview](docs/compliance/README.md)
+- [Platform Hardening Guide](docs/hardening/README.md)
 
 ### Quality, Accessibility, and Operations
 - [QAAndTestplan.md](docs/QAAndTestplan.md)

--- a/docs/compliance/README.md
+++ b/docs/compliance/README.md
@@ -1,0 +1,71 @@
+# Security Compliance Overview
+## Document Control
+- **Owner:** Compliance Programme Director
+- **Version:** 1.0.0
+- **Last Updated:** 2025-02-12
+- **Status:** Approved for distribution to internal teams and auditors
+
+## Purpose
+This document summarises the regulatory frameworks, certification objectives, and
+operational controls that govern LifeVerse's compliance posture. It aligns security,
+privacy, and operational requirements across global jurisdictions.
+
+## Regulatory Landscape
+| Framework | Applicability | Primary Obligations |
+| --- | --- | --- |
+| **GDPR** | EU/EEA players and data subjects | Lawful processing, consent tracking, data subject rights, breach notification within 72 hours. |
+| **CCPA/CPRA** | California residents | Do-not-sell controls, transparent notices, verified consumer requests, data inventory. |
+| **SOC 2 Type II** | Enterprise customers and partners | Security, availability, confidentiality controls with continuous monitoring evidence. |
+| **ISO/IEC 27001** | Global operations | Information security management system (ISMS) governance, risk treatment plans, internal audits. |
+| **PCI DSS SAQ A-EP** | Payment processing integrations | Network segmentation, vulnerability scanning, incident response, third-party management. |
+
+## Governance Model
+- **Compliance Steering Committee:** Quarterly review of control performance, audit
+  findings, and remediation budgets.
+- **Control Owners:** Named individuals for each policy area maintain runbooks and
+  evidence artefacts.
+- **Audit Management:** Dedicated team coordinates external assessors, maintains
+  documentation repositories, and tracks remediation SLAs.
+
+## Policies & Standards
+- Enterprise policies stored in the internal Policy Portal with explicit versioning.
+- Mandatory annual review cycles; emergency updates triggered by regulatory change.
+- Policies mapped to control frameworks using a unified controls matrix.
+
+## Control Execution
+1. **Plan:** Assess changes to products or infrastructure via Compliance Impact
+   Assessments (CIA) before implementation.
+2. **Build:** Embed controls into infrastructure-as-code, CI pipelines, and service
+   configuration baselines.
+3. **Verify:** Capture automated evidence (logs, scan results, tickets) in the
+   Compliance Data Lake; tag with control identifiers.
+4. **Report:** Generate dashboard views for executives, auditors, and product teams.
+
+## Evidence Management
+- All artefacts stored in an immutable S3 bucket with object lock and access logging.
+- Metadata schema captures control ID, owner, review date, and retention requirement.
+- Quarterly self-assessments verify evidence freshness and control effectiveness.
+
+## Audit Readiness Checklist
+- ✅ Control matrix reviewed and signed off by control owners within last quarter.
+- ✅ Incident response and disaster recovery tests executed with documented lessons learned.
+- ✅ Penetration tests and vulnerability scans remediated within SLA windows.
+- ✅ Vendor risk assessments completed for all critical third parties.
+- ✅ Data protection impact assessments (DPIA) updated for new high-risk features.
+
+## Training & Awareness
+- Annual mandatory compliance training for all employees with ≥ 90% completion target.
+- Role-specific briefings for engineers, customer support, and community teams.
+- Monthly newsletters summarising policy updates, regulatory news, and key metrics.
+
+## Continuous Improvement
+- Capture findings from audits, incidents, and retrospectives into the Compliance
+  Improvement Backlog.
+- Prioritise actions based on risk scoring and report progress in steering committee meetings.
+- Update this overview when new regulations, certifications, or regions are added.
+
+## References
+- [Security Policy](../../SECURITY.md)
+- [Platform Hardening Guide](../hardening/README.md)
+- [Data Privacy and Security Plan](../Data-Privacy-and-Security-Plan.md)
+- [Risk Management Document](../RiskManagementDocument.md)

--- a/docs/hardening/README.md
+++ b/docs/hardening/README.md
@@ -1,0 +1,90 @@
+# Platform Hardening Guide
+## Document Control
+- **Owner:** Security Engineering Lead
+- **Version:** 1.0.0
+- **Last Updated:** 2025-02-12
+- **Status:** Approved for internal use
+
+## Purpose
+This guide enumerates the security baselines, configuration controls, and verification
+activities required to harden LifeVerse infrastructure and application deployments.
+It applies to build pipelines, runtime environments, and operational tooling across
+all regions.
+
+## Scope
+- Unreal Engine dedicated servers and container workloads
+- Kubernetes, virtual machine, and bare-metal deployments maintained by LifeVerse
+- Supporting services including databases, cache clusters, messaging queues, and
+  observability stacks
+- Corporate endpoints used to access production environments
+
+## Roles & Responsibilities
+| Function | Responsibilities |
+| --- | --- |
+| **Security Engineering** | Curate baseline configurations, update control catalogs, and review exceptions. |
+| **Platform Engineering** | Apply hardening baselines to infrastructure-as-code, automate compliance checks, and report drift. |
+| **Game & Service Teams** | Ensure application-level settings (logging, auth, secrets) comply with this guide. |
+| **Operations (SRE/NOC)** | Monitor adherence, triage deviations, and maintain incident runbooks. |
+
+## Baseline Controls
+### Identity & Access Management
+- Enforce SSO with phishing-resistant MFA for all privileged identities.
+- Implement just-in-time privilege elevation with automatic expiration.
+- Rotate service credentials every 90 days or sooner when triggered by risk events.
+
+### Network Security
+- Deny-all by default using network security groups, Kubernetes network policies,
+  and security group rules.
+- Terminate TLS 1.2+ at the edge, forwarding mTLS for internal service-to-service
+  communication.
+- Require private connectivity for database, cache, and queue tiers.
+
+### Host & Container Hardening
+- Base images sourced from LifeVerse-maintained hardened AMIs or OCI images.
+- CIS Level 1 benchmarks automated through cloud-init/Ansible profiles.
+- Enforce kernel module allow-lists, disable unused services, and lock down shell access.
+- Run containers as non-root with read-only root filesystems where feasible.
+
+### Data Protection
+- Encrypt all storage using centrally managed KMS keys with rotation every 12 months.
+- Apply row-level or field-level encryption for PII and payment data domains.
+- Enforce database auditing with immutable storage in the security logging account.
+
+### Application Security
+- Block unsigned binaries and enforce code-signing validation during deployment.
+- Apply secure default configurations for Unreal dedicated servers (command-line
+  whitelists, rate limits, anti-cheat modules).
+- Validate configuration through automated integration tests before promoting to staging.
+
+## Automation & Tooling
+- Infrastructure-as-code repositories must include OPA/Conftest policies covering
+  the controls above.
+- CI pipelines execute SAST, SCA, and container scanning with fail gates for
+  critical findings.
+- Drift detection alerts raise PagerDuty incidents when baselines diverge.
+- Centralised dashboards expose compliance posture and remediation SLAs.
+
+## Verification Activities
+| Cadence | Activity | Owner |
+| --- | --- | --- |
+| Per deployment | Preflight configuration scans | Platform Engineering |
+| Weekly | Drift and vulnerability review | Security Engineering |
+| Quarterly | Penetration testing of representative environments | External partner |
+| Annually | Tabletop exercises covering containment and recovery | Security + Operations |
+
+## Exception Management
+- Document exceptions in the Security Risk Register with compensating controls and
+  expiration dates.
+- Exceptions require approval from the Security Engineering Lead and Product VP.
+- Expired exceptions trigger automatic revocation and regression testing.
+
+## Incident Response Integration
+- Hardening deviations discovered during incidents feed lessons learned and
+  updates into this guide.
+- Maintain runbooks for containment (isolation, credential rotation, traffic
+  filtering) aligned with the Incident Response Plan.
+
+## References
+- [Security Policy](../../SECURITY.md)
+- [Security Compliance Overview](../compliance/README.md)
+- [Risk Management Framework](../RiskManagementDocument.md)


### PR DESCRIPTION
## Summary
- add a security compliance overview covering regulatory frameworks, evidence management, and training expectations
- add a platform hardening guide outlining baselines for infrastructure, applications, and verification activities
- link the new documentation from the README security section for discoverability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f91f4ae0a4832c84ea7ada84ce2ff4